### PR TITLE
Boolean Column Support

### DIFF
--- a/src/main/java/org/hrorm/BooleanConverter.java
+++ b/src/main/java/org/hrorm/BooleanConverter.java
@@ -1,5 +1,7 @@
 package org.hrorm;
 
+import java.util.Objects;
+
 /**
  * This {@link Converter} translates true values to "T" and false
  * values to "F".
@@ -10,14 +12,20 @@ package org.hrorm;
  */
 public class BooleanConverter implements Converter<Boolean, String> {
 
-    public static final BooleanConverter INSTANCE = new BooleanConverter();
+    private final String trueRepresentation;
+    private final String falseRepresentation;
+
+    public BooleanConverter(String trueRepresentation, String falseRepresentation) {
+        this.trueRepresentation = trueRepresentation;
+        this.falseRepresentation = falseRepresentation;
+    }
 
     @Override
     public String from(Boolean aBoolean) {
         if ( aBoolean == null ) {
             return null;
         }
-        return aBoolean ? "T" : "F";
+        return aBoolean ? trueRepresentation : falseRepresentation;
     }
 
     @Override
@@ -25,10 +33,11 @@ public class BooleanConverter implements Converter<Boolean, String> {
         if ( s == null ){
             return null;
         }
-        switch (s) {
-            case "T" : return Boolean.TRUE;
-            case "F" : return Boolean.FALSE;
-            default : throw new HrormException("Unsupported string: " + s);
+        if (Objects.equals(s, trueRepresentation)) {
+            return Boolean.TRUE;
+        } else if (Objects.equals(s, falseRepresentation)) {
+            return Boolean.FALSE;
         }
+        throw new HrormException("Unsupported string: " + s);
     }
 }

--- a/src/main/java/org/hrorm/ColumnTypes.java
+++ b/src/main/java/org/hrorm/ColumnTypes.java
@@ -19,6 +19,18 @@ import java.util.Set;
  */
 public class ColumnTypes {
 
+
+    public static final Set<Integer> BooleanTypes =
+            Collections.unmodifiableSet(
+                    new HashSet<>(Arrays.asList(
+                            Types.INTEGER,
+                            Types.BIGINT,
+                            Types.SMALLINT,
+                            Types.BIT,
+                            Types.BOOLEAN,
+                            Types.NUMERIC
+                    )));
+
     public static final Set<Integer> IntegerTypes =
             Collections.unmodifiableSet(
                     new HashSet<>(Arrays.asList(

--- a/src/main/java/org/hrorm/DataColumnFactory.java
+++ b/src/main/java/org/hrorm/DataColumnFactory.java
@@ -76,6 +76,34 @@ public class DataColumnFactory {
         };
     }
 
+    public static <ENTITY,BUILDER> AbstractColumn<Boolean, ENTITY, BUILDER> booleanColumn(
+            String name, String prefix, Function<ENTITY, Boolean> getter, BiConsumer<BUILDER, Boolean> setter, boolean nullable){
+        return new AbstractColumn<Boolean, ENTITY, BUILDER>(name, prefix, getter, setter, nullable) {
+            @Override
+            public Boolean fromResultSet(ResultSet resultSet, String columnName) throws SQLException {
+                return resultSet.getBoolean(columnName);
+            }
+
+            @Override
+            public void setPreparedStatement(PreparedStatement preparedStatement, int index, Boolean value) throws SQLException {
+                preparedStatement.setBoolean(index, value);
+            }
+
+            @Override
+            public Column<ENTITY, BUILDER> withPrefix(String newPrefix, Prefixer prefixer) {
+                return booleanColumn(getName(), newPrefix, getter, setter, nullable);
+            }
+
+            @Override
+            int sqlType() {
+                return Types.INTEGER;
+            }
+
+            @Override
+            public Set<Integer> supportedTypes() { return ColumnTypes.BooleanTypes; }
+        };
+    }
+
     public static <ENTITY,BUILDER> AbstractColumn<String, ENTITY, BUILDER> stringColumn(
             String name, String prefix, Function<ENTITY, String> getter, BiConsumer<BUILDER, String> setter, boolean nullable){
         return new AbstractColumn<String, ENTITY, BUILDER>(name, prefix, getter, setter, nullable) {

--- a/src/main/java/org/hrorm/DataColumnFactory.java
+++ b/src/main/java/org/hrorm/DataColumnFactory.java
@@ -96,7 +96,7 @@ public class DataColumnFactory {
 
             @Override
             int sqlType() {
-                return Types.INTEGER;
+                return Types.BOOLEAN;
             }
 
             @Override

--- a/src/main/java/org/hrorm/IndirectDaoBuilder.java
+++ b/src/main/java/org/hrorm/IndirectDaoBuilder.java
@@ -244,7 +244,7 @@ public class IndirectDaoBuilder<ENTITY, BUILDER>  implements DaoDescriptor<ENTIT
      * @return This instance.
      */
     public IndirectDaoBuilder<ENTITY, BUILDER> withBooleanColumn(String columnName, Function<ENTITY, Boolean> getter, BiConsumer<BUILDER, Boolean> setter){
-        Column<ENTITY, BUILDER> column = DataColumnFactory.stringConverterColumn(columnName, myPrefix, getter, setter, BooleanConverter.INSTANCE, true);
+        Column<ENTITY, BUILDER> column = DataColumnFactory.booleanColumn(columnName, myPrefix, getter, setter, true);
         columns.add(column);
         lastColumnAdded = column;
         return this;

--- a/src/test/resources/schemas/columns.sql
+++ b/src/test/resources/schemas/columns.sql
@@ -5,7 +5,7 @@ create table columns_table (
   string_column text,
   integer_column integer,
   decimal_column decimal,
-  boolean_column text,
+  boolean_column integer,
   timestamp_column timestamp,
   color_column text
 );

--- a/src/test/resources/schemas/complex.sql
+++ b/src/test/resources/schemas/complex.sql
@@ -40,7 +40,7 @@ create table EDITH (
 create sequence FRED_SEQUENCE;
 create table FRED (
       id integer PRIMARY KEY,
-      flag text
+      flag integer
 );
 
 create sequence GAP_SEQUENCE;

--- a/src/test/resources/schemas/immutable_thing.sql
+++ b/src/test/resources/schemas/immutable_thing.sql
@@ -11,7 +11,7 @@ create sequence immutable_child_seq;
 create table immutable_child (
     id integer primary key,
     birthday timestamp,
-    flag text,
+    flag integer,
     sibling_id integer,
     thing_id integer
 );

--- a/src/test/resources/schemas/keyless.sql
+++ b/src/test/resources/schemas/keyless.sql
@@ -2,6 +2,6 @@ create table keyless_table (
   string_column text,
   integer_column integer,
   decimal_column decimal,
-  boolean_column text,
+  boolean_column integer,
   timestamp_column timestamp
 );


### PR DESCRIPTION
First jab at supporting boolean fields as numeric/bit/boolean type columns. String columns are no longer supported- for that, I would suggest using withConvertingStringColumn because it eliminates ambiguity. 

BooleanConverter is no longer used but updated to allow for easy construction of a converter that will accept the user's preference on how to represent their boolean value as a string in the database.

Significant changes needed to happen to many of the .sql files under tests for them to pass, those changes should be subject to high scrutiny. I changed all 'flag' columns from 'text' to 'integer'.

Its likely additional test coverage is necessary, this is all the time I have for this at the current moment- I may be able to revisit this later in the week.